### PR TITLE
use bitwise ops rather than B to check for numeric flags

### DIFF
--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -6,7 +6,6 @@ package JSON::Tiny;
 
 use strict;
 use warnings;
-use B;
 use Carp qw/carp croak/;
 use Exporter 'import';
 use Scalar::Util 'blessed';
@@ -264,8 +263,10 @@ sub _encode_value {
   return 'null' unless defined $value;
 
   # Number
+  my $check = "0" & $value;
   return $value
-    if B::svref_2object(\$value)->FLAGS & (B::SVp_IOK | B::SVp_NOK)
+    if !($check ^ $check)
+    && length $check
     && 0 + $value eq $value
     && $value * 0 == 0;
 

--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -6,7 +6,6 @@ package JSON::Tiny;
 
 use strict;
 use warnings;
-use utf8;
 use B;
 use Carp qw/carp croak/;
 use Exporter 'import';


### PR DESCRIPTION
This abuses the fact that bitwise ops change behavior based on the
internal type of a value.  This avoids the memory cost of loading B, and
ends up being faster as well.

We first us an & to shorten the input, so we don't end up operating on a
long string.

"0" & 0       -> 0
"0" & ""      -> ""
"0" & $string -> $character

0 ^ 0                    -> 0 (false)
$character ^ $character  -> "\x00" (true)

Previous attempts to use this technique didn't include the & step to shorten the value, and were thus slower than using B for long strings.
