### PR TITLE
use bitwise ops rather than B to check for numeric flags

### DIFF
--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -265,9 +265,11 @@ sub _encode_value {
 
   # Number (bitwise operators change behavior based on the internal value type)
 
+  # "0" & $x will modify the flags on the "0" on perl < 5.14, so use a copy
+  my $zero = "0";
   # "0" & $num -> 0. "0" & "" -> "". "0" & $string -> a character.
   # this maintains the internal type but speeds up the xor below.
-  my $check = "0" & $value;
+  my $check = $zero & $value;
   return $value
     if length $check
     # 0 ^ itself          -> 0    (false)

--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -6,7 +6,6 @@ package JSON::Tiny;
 
 use strict;
 use warnings;
-use utf8;
 use B;
 use Carp qw/carp croak/;
 use Exporter 'import';


### PR DESCRIPTION
This abuses the fact that bitwise ops change behavior based on the
internal type of a value. This avoids the memory cost of loading B, and
ends up being faster as well.

We first us an & to shorten the input, so we don't end up operating on a
long string.

"0" & 0 -> 0
"0" & "" -> ""
"0" & $string -> $character

0 ^ 0 -> 0 (false)
$character ^ $character -> "\x00" (true)

Previous attempts to use this technique didn't include the & step to shorten the value, and were thus slower than using B for long strings.

This is a revision of PR #1, including a fix for perl < 5.14, as well as documenting the purpose of the checks better.
